### PR TITLE
[CI-4129] Add test plan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
 | `product_path` | The path of the test bundle.  The step supports the following formats: - xcresrun - xctestproducts  It will use the specified file to collect the built tests and generate the test shards. | required |  |
+| `test_plan` | Shard the provided test plan's test.  Leave this input empty to run the default Test Plan or Test Targets associated with the Scheme.  The input value sets xcodebuild's `-testPlan` option. |  |  |
 | `shard_count` | The number of test shards to create.  The output folder will contain `shard_count` number of files, each containing the tests to run in that shard. | required |  |
 | `shard_calculation` | Defines the strategy to use when splitting the tests into shards  The available options are: - `alphabetically`: The tests are sorted alphabetically and split into shards | required | `alphabetically` |
 | `destination` | Destination specifier describes the device to use as a destination.  The input value sets xcodebuild's `-destination` option.  In a CI environment, a Simulator device called `Bitrise iOS default` is already created. It is a compatible device with the selected Simulator runtime, pre-warmed for better performance.  If a device with this name is not found (e.g. in a local dev environment), the first matching device will be selected. | required | `platform=iOS Simulator,name=Bitrise iOS default,OS=latest` |

--- a/step.yml
+++ b/step.yml
@@ -46,6 +46,17 @@ inputs:
       It will use the specified file to collect the built tests and generate the test shards.
     is_required: true
 
+- test_plan:
+  opts:
+    title: Test Plan
+    summary: Shard the provided test plan's test.
+    description: |-
+      Shard the provided test plan's test.
+
+      Leave this input empty to run the default Test Plan or Test Targets associated with the Scheme.
+
+      The input value sets xcodebuild's `-testPlan` option.
+
 - shard_count:
   opts:
     title: Shard count

--- a/step/step.go
+++ b/step/step.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/bitrise-io/go-steputils/v2/export"
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
-	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -25,6 +24,7 @@ var ErrXcodebuildFailed = errors.New("unexpected xcodebuild failure")
 
 type Input struct {
 	ProductPath      string `env:"product_path,required"`
+	TestPlan         string `env:"test_plan"`
 	ShardCount       int    `env:"shard_count,required"`
 	ShardCalculation string `env:"shard_calculation,opt[alphabetically]"`
 	Destination      string `env:"destination,required"`
@@ -33,6 +33,7 @@ type Input struct {
 
 type Config struct {
 	ProductPath      string
+	TestPlan         string
 	ShardCount       int
 	ShardCalculation string
 	Destination      string
@@ -108,7 +109,7 @@ func (s *Step) Run(config Config) (Result, error) {
 	err := retry.Times(3).Wait(10).TryWithAbort(func(attempt uint) (error, bool) {
 		s.logger.Infof("%d. attempt", attempt+1)
 
-		testList, err := s.collectTests(config.ProductPath, config.Destination)
+		testList, err := s.collectTests(config.ProductPath, config.TestPlan, config.Destination)
 		if err != nil {
 			if errors.Is(err, ErrXcodebuildFailed) {
 				s.logger.Warnf("Test collection failed: %s", err)
@@ -185,7 +186,7 @@ func (s *Step) getSimulatorForDestination(destinationSpecifier string) (destinat
 	return device, nil
 }
 
-func (s *Step) collectTests(testProductsPath, destination string) ([]string, error) {
+func (s *Step) collectTests(testProductsPath, testPlan, destination string) ([]string, error) {
 	tmpDir, err := createTempFolder()
 	if err != nil {
 		return nil, err
@@ -209,6 +210,10 @@ func (s *Step) collectTests(testProductsPath, destination string) ([]string, err
 		return nil, fmt.Errorf("unsupported test products file extension: %s", testProductsPath)
 	}
 
+	if testPlan != "" {
+		options = append(options, "-testPlan", testPlan)
+	}
+
 	cmd := s.commandFactory.Create("xcodebuild", options, &command.Opts{
 		Stdout: os.Stdout,
 		Stderr: os.Stdout,
@@ -228,14 +233,15 @@ func (s *Step) collectTests(testProductsPath, destination string) ([]string, err
 		return nil, err
 	}
 
-	return processTestResults(bytes)
+	return processTestResults(bytes, testPlan)
 }
 
-func processTestResults(result []byte) ([]string, error) {
+func processTestResults(result []byte, testPlan string) ([]string, error) {
 	type testData struct {
 		Errors []string `json:"errors"`
 		Values []struct {
-			Tests []struct {
+			TestPlan string `json:"testPlan"`
+			Tests    []struct {
 				Identifier string `json:"identifier"`
 			} `json:"enabledTests"`
 		} `json:"values"`
@@ -252,9 +258,17 @@ func processTestResults(result []byte) ([]string, error) {
 
 	var tests []string
 	for _, value := range data.Values {
+		if testPlan != "" && testPlan != value.TestPlan {
+			continue
+		}
+
 		for _, test := range value.Tests {
 			tests = append(tests, test.Identifier)
 		}
+	}
+
+	if len(tests) == 0 {
+		return nil, fmt.Errorf("failed to find tests for '%s' test plan", testPlan)
 	}
 
 	return tests, nil

--- a/step/step.go
+++ b/step/step.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bitrise-io/go-steputils/v2/export"
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
+	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -1,6 +1,7 @@
 package step
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,33 +18,131 @@ import (
 	"github.com/bitrise-steplib/bitrise-step-xcode-test-shard-calculation/mocks"
 )
 
+const (
+	singleTestPlan = `
+{
+  "values" : [
+    {
+      "enabledTests" : [
+        {
+          "identifier" : "Target/Class/test1"
+        },
+        {
+          "identifier" : "Target/Class/test2"
+        },
+        {
+          "identifier" : "Target/Class/test3"
+        },
+        {
+          "identifier" : "Target/Class/test4"
+        },
+        {
+          "identifier" : "Target/Class/test5"
+        },
+        {
+          "identifier" : "Target/Class/test6"
+        }
+      ],
+      "testPlan" : "Tests"
+    }
+  ]
+}
+`
+	multipleTestPlan = `
+{
+  "values" : [
+    {
+      "enabledTests" : [
+        {
+          "identifier" : "Target/Class/test1"
+        },
+        {
+          "identifier" : "Target/Class/test2"
+        }
+      ],
+      "testPlan" : "TestPlan1"
+    },
+    {
+      "enabledTests" : [
+        {
+          "identifier" : "Target/Class/test3"
+        },
+        {
+          "identifier" : "Target/Class/test4"
+        }
+      ],
+      "testPlan" : "TestPlan2"
+    }
+  ]
+}
+`
+)
+
 func TestRun(t *testing.T) {
-	step, testingMocks := createStepAndMocks(t)
-	testingMocks.command.On("PrintableCommandArgs").Return("", nil)
-	testingMocks.command.On("Run").Return(nil)
-
-	call := testingMocks.commandFactory.On("Create", "xcodebuild", mock.Anything, mock.Anything)
-	call.RunFn = func(arguments mock.Arguments) {
-		saveTestData(t, arguments)
-
-		call.ReturnArguments = mock.Arguments{testingMocks.command, nil}
+	testCases := []struct {
+		name          string
+		testPlan      string
+		testList      string
+		expectedFiles map[string]string
+		expectedError error
+	}{
+		{
+			name:     "Default test plan",
+			testList: singleTestPlan,
+			expectedFiles: map[string]string{
+				"0": "Target/Class/test1\nTarget/Class/test2\nTarget/Class/test3\n",
+				"1": "Target/Class/test4\nTarget/Class/test5\nTarget/Class/test6\n",
+			},
+		},
+		{
+			name:     "User selected test plan",
+			testPlan: "TestPlan2",
+			testList: multipleTestPlan,
+			expectedFiles: map[string]string{
+				"0": "Target/Class/test3\n",
+				"1": "Target/Class/test4\n",
+			},
+		},
+		{
+			name:          "User selects non-existing test plan",
+			testPlan:      "Does not exist",
+			testList:      multipleTestPlan,
+			expectedError: fmt.Errorf("failed to find tests for 'Does not exist' test plan"),
+		},
 	}
 
-	result, err := step.Run(Config{
-		ProductPath: "test.xctestrun",
-		ShardCount:  2,
-		Destination: "test-device",
-	})
-	require.NoError(t, err)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			step, testingMocks := createStepAndMocks(t)
+			testingMocks.command.On("PrintableCommandArgs").Return("", nil)
+			testingMocks.command.On("Run").Return(nil)
 
-	files, err := contents(t, result.TestShardsDir)
-	require.NoError(t, err)
+			call := testingMocks.commandFactory.On("Create", "xcodebuild", mock.Anything, mock.Anything)
+			call.RunFn = func(arguments mock.Arguments) {
+				saveTestData(t, arguments, testCase.testList)
 
-	expectedFiles := map[string]string{
-		"0": "Target/Class/test1\nTarget/Class/test2\nTarget/Class/test3\n",
-		"1": "Target/Class/test4\nTarget/Class/test5\nTarget/Class/test6\n",
+				call.ReturnArguments = mock.Arguments{testingMocks.command, nil}
+			}
+
+			result, err := step.Run(Config{
+				ProductPath: "test.xctestrun",
+				TestPlan:    testCase.testPlan,
+				ShardCount:  2,
+				Destination: "test-device",
+			})
+			if testCase.expectedError != nil {
+				require.EqualError(t, err, testCase.expectedError.Error())
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			files, err := contents(t, result.TestShardsDir)
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.expectedFiles, files)
+		})
 	}
-	assert.Equal(t, expectedFiles, files)
 }
 
 func contents(t *testing.T, path string) (map[string]string, error) {
@@ -96,7 +195,7 @@ func TestSupportedProductTypes(t *testing.T) {
 
 			call := testingMocks.commandFactory.On("Create", "xcodebuild", mock.Anything, mock.Anything)
 			call.RunFn = func(arguments mock.Arguments) {
-				saveTestData(t, arguments)
+				saveTestData(t, arguments, singleTestPlan)
 
 				call.ReturnArguments = mock.Arguments{testingMocks.command, nil}
 			}
@@ -117,7 +216,7 @@ func TestSupportedProductTypes(t *testing.T) {
 	}
 }
 
-func saveTestData(t *testing.T, arguments mock.Arguments) {
+func saveTestData(t *testing.T, arguments mock.Arguments, testData string) {
 	path := ""
 	params := arguments[1].([]string)
 
@@ -132,36 +231,7 @@ func saveTestData(t *testing.T, arguments mock.Arguments) {
 		t.Fail()
 	}
 
-	data := `
-{
-  "values" : [
-    {
-      "enabledTests" : [
-        {
-          "identifier" : "Target/Class/test1"
-        },
-        {
-          "identifier" : "Target/Class/test2"
-        },
-        {
-          "identifier" : "Target/Class/test3"
-        },
-        {
-          "identifier" : "Target/Class/test4"
-        },
-        {
-          "identifier" : "Target/Class/test5"
-        },
-        {
-          "identifier" : "Target/Class/test6"
-        }
-      ],
-      "testPlan" : "Tests"
-    }
-  ]
-}
-`
-	err := os.WriteFile(path, []byte(data), 0644)
+	err := os.WriteFile(path, []byte(testData), 0644)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
<!--

  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

The step only supported the default test plan from the scheme settings. With this PR users can override this just like with out other Xcode related steps.